### PR TITLE
ci: fix ghp-import by keeping SSH_AUTH_SOCK env var

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -45,7 +45,10 @@ pipeline {
                 -b ${deployBranch()} \
                 -c ${deployDomain()} \
                 -p build
-            """, sandbox: false)
+              """,
+              sandbox: false,
+              envKeep: ['SSH_AUTH_SOCK'],
+            )
           }
         }
       }


### PR DESCRIPTION
Fixes:
```
trace: run_command: unset GIT_PREFIX; ssh git@github.com 'git-receive-pack '\''codex-storage/guide.codex.storage.git'\'''
git@github.com: Permission denied (publickey).
```
